### PR TITLE
dockerfile uses centos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
-FROM centos/python-27-centos7:latest
+FROM centos:latest
 
 ADD requirements.txt .
+
+RUN yum -y install epel-release && \
+    yum -y install python-pip && \
+    yum clean all
 
 RUN pip install -r requirements.txt
 


### PR DESCRIPTION
The dockerfile now uses the centos image as this is more likely to have been enterprise tested with less vulnerabilities instead of the python image. The centos/python image was taken out as it was too flakey when building. The epel release is used to install pip